### PR TITLE
Refactor extract translation.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,10 @@ Layout/LineLength:
 Naming/FileName:
   Exclude:
     - 'lib/i18n-ai.rb'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'i18n-ai.gemspec'
+
+Style/Documentation:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,7 @@ Metrics/BlockLength:
 
 Style/Documentation:
   Enabled: false
+
+Style/BlockDelimiters:
+  Exclude:
+    - 'spec/**/*_spec.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    i18n-ai (0.1.3)
+    i18n-ai (0.1.4)
       anthropic
       railties (>= 6.0.0, < 8)
       ruby-openai

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,13 +28,19 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     anthropic (0.3.0)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
     ast (2.4.2)
+    bigdecimal (3.1.8)
     builder (3.3.0)
     concurrent-ruby (1.3.3)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     diff-lcs (1.5.1)
     erubi (1.13.0)
@@ -46,6 +52,7 @@ GEM
       multipart-post (~> 2)
     faraday-net_http (3.1.1)
       net-http
+    hashdiff (1.1.1)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
@@ -69,6 +76,7 @@ GEM
     parser (3.3.4.0)
       ast (~> 2.4.1)
       racc
+    public_suffix (6.0.1)
     racc (1.8.1)
     rack (2.2.9)
     rack-test (2.1.0)
@@ -128,6 +136,11 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
+    vcr (6.2.0)
+    webmock (3.23.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     zeitwerk (2.6.17)
 
 PLATFORMS
@@ -139,6 +152,8 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
+  vcr
+  webmock
 
 BUNDLED WITH
    2.5.13

--- a/i18n-ai.gemspec
+++ b/i18n-ai.gemspec
@@ -33,8 +33,12 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_runtime_dependency("railties", ">= 6.0.0", "< 8")
+
   spec.add_dependency "anthropic"
   spec.add_dependency "ruby-openai"
+
+  spec.add_development_dependency "vcr"
+  spec.add_development_dependency "webmock"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/i18n_ai/clients/anthropic_client.rb
+++ b/lib/i18n_ai/clients/anthropic_client.rb
@@ -7,47 +7,50 @@ module I18nAi
   module Clients
     # The AnthropicClient class is responsible for interacting with the Anthropic API
     class AnthropicClient < BaseClient
+      attr_reader :client
+
       def initialize
         super
-        @client = Anthropic::Client.new(
-          access_token: @config[:access_token]
-        )
+        @client = Anthropic::Client.new(access_token: config[:access_token])
       end
 
       def chat(locale, text)
-        response = @client.messages(
+        response = client.messages(
           parameters: {
-            model: @config[:model],
-            messages: [{ role: "user", content: chat_prompt(locale, text) }]
+            model: config[:model],
+            messages: [{ role: "user", content: chat_prompt(locale, text) }],
+            max_tokens: 1024
           }
         )
-
         parse_response(response)
-      rescue StandardError => e
-        handle_error(e)
       end
 
       private
 
       def chat_prompt(locale, text_to_translate)
-        # rubocop:disable Layout/LineLength
-        "Translate the following YAML content to #{locale.to_s.upcase} and make sure to retain the keys in english except the first key which is the 2 letter language code:\n\n#{text_to_translate}"
-        # rubocop:enable Layout/LineLength
+        <<~PROMPT
+          Translate the following YAML content to the language of the country using the ISO 639 language code
+          of #{locale}. Make sure to retain the keys in english except the first key which is the 2 letter language code:
+
+          """"
+          #{text_to_translate}"
+          """"
+
+          Return only YAML content without explanation.
+
+          Example:
+
+            {{two_letter_locale_abbrev}}:
+              key_1: "value1"
+        PROMPT
       end
 
       def parse_response(response)
         response.dig("content", 0, "text")
-      rescue TypeError, NoMethodError => e
-        handle_error(e)
-      end
-
-      def handle_error(error)
-        puts "Error: #{error.message}"
       end
 
       def extract_translated_content(chat_content)
-        match_data = response.match(/```yaml(.*?)```/m)
-        match_data ? match_data[1].strip : nil
+        chat_content
       end
     end
   end

--- a/lib/i18n_ai/clients/anthropic_client.rb
+++ b/lib/i18n_ai/clients/anthropic_client.rb
@@ -19,7 +19,7 @@ module I18nAi
           parameters: {
             model: config[:model],
             messages: [{ role: "user", content: chat_prompt(locale, text) }],
-            max_tokens: 5000
+            max_tokens: 4096
           }
         )
         parse_response(response)

--- a/lib/i18n_ai/clients/anthropic_client.rb
+++ b/lib/i18n_ai/clients/anthropic_client.rb
@@ -18,7 +18,7 @@ module I18nAi
         response = @client.messages(
           parameters: {
             model: @config[:model],
-            messages: [{ role: "user", content: content(locale, text) }]
+            messages: [{ role: "user", content: chat_prompt(locale, text) }]
           }
         )
 
@@ -29,6 +29,12 @@ module I18nAi
 
       private
 
+      def chat_prompt(locale, text_to_translate)
+        # rubocop:disable Layout/LineLength
+        "Translate the following YAML content to #{locale.to_s.upcase} and make sure to retain the keys in english except the first key which is the 2 letter language code:\n\n#{text_to_translate}"
+        # rubocop:enable Layout/LineLength
+      end
+
       def parse_response(response)
         response.dig("content", 0, "text")
       rescue TypeError, NoMethodError => e
@@ -37,6 +43,11 @@ module I18nAi
 
       def handle_error(error)
         puts "Error: #{error.message}"
+      end
+
+      def extract_translated_content(chat_content)
+        match_data = response.match(/```yaml(.*?)```/m)
+        match_data ? match_data[1].strip : nil
       end
     end
   end

--- a/lib/i18n_ai/clients/anthropic_client.rb
+++ b/lib/i18n_ai/clients/anthropic_client.rb
@@ -7,43 +7,25 @@ module I18nAi
   module Clients
     # The AnthropicClient class is responsible for interacting with the Anthropic API
     class AnthropicClient < BaseClient
-      attr_reader :client
-
       def initialize
         super
-        @client = Anthropic::Client.new(access_token: config[:access_token])
+        @client = Anthropic::Client.new(
+          access_token: config[:access_token]
+        )
       end
 
       def chat(locale, text)
-        response = client.messages(
+        response = @client.messages(
           parameters: {
             model: config[:model],
             messages: [{ role: "user", content: chat_prompt(locale, text) }],
-            max_tokens: 1024
+            max_tokens: 5000
           }
         )
         parse_response(response)
       end
 
       private
-
-      def chat_prompt(locale, text_to_translate)
-        <<~PROMPT
-          Translate the following YAML content to the language of the country using the ISO 639 language code
-          of #{locale}. Make sure to retain the keys in english except the first key which is the 2 letter language code:
-
-          """"
-          #{text_to_translate}"
-          """"
-
-          Return only YAML content without explanation.
-
-          Example:
-
-            {{two_letter_locale_abbrev}}:
-              key_1: "value1"
-        PROMPT
-      end
 
       def parse_response(response)
         response.dig("content", 0, "text")

--- a/lib/i18n_ai/clients/base_client.rb
+++ b/lib/i18n_ai/clients/base_client.rb
@@ -28,10 +28,12 @@ module I18nAi
 
           Return only the YAML content without explanation.
 
-          Example:
+          Example Return YAML:
 
-            {{two_letter_locale_abbrev}}:
-              key_1: "value1"
+          """
+          {{ISO_639 language code}}:
+            key_1: "value1"
+          """
         PROMPT
       end
 

--- a/lib/i18n_ai/clients/base_client.rb
+++ b/lib/i18n_ai/clients/base_client.rb
@@ -17,11 +17,25 @@ module I18nAi
 
       private
 
-      def chat(locale, text)
-        raise NotImplementedError, "Subclasses must implement this method"
+      def chat_prompt(locale, text_to_translate)
+        <<~PROMPT
+          Translate the following YAML content to the language of the country using the ISO 639 language code
+          of #{locale}. Make sure to retain the keys in english except the first key which is the 2 letter language code:
+
+          """"
+          #{text_to_translate}"
+          """"
+
+          Return only the YAML content without explanation.
+
+          Example:
+
+            {{two_letter_locale_abbrev}}:
+              key_1: "value1"
+        PROMPT
       end
 
-      def chat_prompt(locale, text_to_translate)
+      def chat(locale, text)
         raise NotImplementedError, "Subclasses must implement this method"
       end
 

--- a/lib/i18n_ai/clients/base_client.rb
+++ b/lib/i18n_ai/clients/base_client.rb
@@ -8,13 +8,26 @@ module I18nAi
         @config = I18nAi.configuration.ai_settings
       end
 
-      def content(locale, text_to_translate)
-        # rubocop:disable Layout/LineLength
-        "Translate the following YAML content to #{locale.to_s.upcase} and make sure to retain the keys in english except the first key which is the 2 letter language code:\n\n#{text_to_translate}"
-        # rubocop:enable Layout/LineLength
+      def translate_content(locale, content)
+        chat_content = chat(locale, content)
+        extract_translated_content(chat_content)
+      end
+
+      private
+
+      def chat(locale, text)
+        raise NotImplementedError, "Subclasses must implement this method"
+      end
+
+      def chat_prompt(locale, text_to_translate)
+        raise NotImplementedError, "Subclasses must implement this method"
       end
 
       def parse_response(response)
+        raise NotImplementedError, "Subclasses must implement this method"
+      end
+
+      def extract_translated_content
         raise NotImplementedError, "Subclasses must implement this method"
       end
     end

--- a/lib/i18n_ai/clients/base_client.rb
+++ b/lib/i18n_ai/clients/base_client.rb
@@ -4,6 +4,8 @@ module I18nAi
   module Clients
     # The BaseClient class serves as a base class for all AI client implementations
     class BaseClient
+      attr_reader :config
+
       def initialize
         @config = I18nAi.configuration.ai_settings
       end

--- a/lib/i18n_ai/clients/base_client.rb
+++ b/lib/i18n_ai/clients/base_client.rb
@@ -29,7 +29,7 @@ module I18nAi
         raise NotImplementedError, "Subclasses must implement this method"
       end
 
-      def extract_translated_content
+      def extract_translated_content(chat_content)
         raise NotImplementedError, "Subclasses must implement this method"
       end
     end

--- a/lib/i18n_ai/clients/open_ai_client.rb
+++ b/lib/i18n_ai/clients/open_ai_client.rb
@@ -5,12 +5,11 @@ require_relative "base_client"
 
 module I18nAi
   module Clients
-    # The AnthropicClient class is responsible for interacting with the OpenAI API
     class OpenAiClient < BaseClient
       def initialize
         super
         @client = OpenAI::Client.new(
-          access_token: @config[:access_token],
+          access_token: config[:access_token],
           log_errors: true
         )
       end
@@ -23,19 +22,10 @@ module I18nAi
             max_tokens: 5000
           }
         )
-
         parse_response(response)
-      rescue StandardError => e
-        handle_error(e)
       end
 
       private
-
-      def chat_prompt(locale, text_to_translate)
-        # rubocop:disable Layout/LineLength
-        "Translate the following YAML content to #{locale.to_s.upcase} and make sure to retain the keys in english except the first key which is the 2 letter language code:\n\n#{text_to_translate}"
-        # rubocop:enable Layout/LineLength
-      end
 
       def parse_response(response)
         response.dig("choices", 0, "message", "content")
@@ -48,7 +38,7 @@ module I18nAi
       end
 
       def extract_translated_content(chat_content)
-        match_data = response.match(/```yaml(.*?)```/m)
+        match_data = chat_content.match(/```yaml(.*?)```/m)
         match_data ? match_data[1].strip : nil
       end
     end

--- a/lib/i18n_ai/clients/open_ai_client.rb
+++ b/lib/i18n_ai/clients/open_ai_client.rb
@@ -19,7 +19,7 @@ module I18nAi
         response = @client.chat(
           parameters: {
             model: @config[:model],
-            messages: [{ role: "user", content: content(locale, text) }],
+            messages: [{ role: "user", content: chat_prompt(locale, text) }],
             max_tokens: 5000
           }
         )
@@ -31,6 +31,12 @@ module I18nAi
 
       private
 
+      def chat_prompt(locale, text_to_translate)
+        # rubocop:disable Layout/LineLength
+        "Translate the following YAML content to #{locale.to_s.upcase} and make sure to retain the keys in english except the first key which is the 2 letter language code:\n\n#{text_to_translate}"
+        # rubocop:enable Layout/LineLength
+      end
+
       def parse_response(response)
         response.dig("choices", 0, "message", "content")
       rescue TypeError, NoMethodError => e
@@ -39,6 +45,11 @@ module I18nAi
 
       def handle_error(error)
         puts "Error: #{error.message}"
+      end
+
+      def extract_translated_content(chat_content)
+        match_data = response.match(/```yaml(.*?)```/m)
+        match_data ? match_data[1].strip : nil
       end
     end
   end

--- a/lib/i18n_ai/clients/open_ai_client.rb
+++ b/lib/i18n_ai/clients/open_ai_client.rb
@@ -19,7 +19,7 @@ module I18nAi
           parameters: {
             model: @config[:model],
             messages: [{ role: "user", content: chat_prompt(locale, text) }],
-            max_tokens: 5000
+            max_tokens: 4096
           }
         )
         parse_response(response)

--- a/lib/i18n_ai/railtie.rb
+++ b/lib/i18n_ai/railtie.rb
@@ -86,9 +86,7 @@ module I18nAi
 
         generate_locales.each do |locale|
           translated_content = client.translate_content(locale, text_to_translate)
-          if translated_content
-            save_translated_locales(locale, translated_content)
-          end
+          save_translated_locales(locale, translated_content) if translated_content
         end
       end
 

--- a/lib/i18n_ai/version.rb
+++ b/lib/i18n_ai/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module I18nAi
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/spec/clients/anthropic_client_spec.rb
+++ b/spec/clients/anthropic_client_spec.rb
@@ -3,79 +3,30 @@
 module I18nAi
   module Clients
     RSpec.describe AnthropicClient do
-      let(:config) { { access_token: "test_token", model: "test_model" } }
-      let(:client) { described_class.new }
-
       before do
-        allow(I18nAi).to receive_message_chain(:configuration, :ai_settings).and_return(config)
-      end
-
-      describe "#initialize" do
-        it "initializes the Anthropic client with the correct access token" do
-          expect(Anthropic::Client).to receive(:new).with(access_token: config[:access_token])
-          client
+        I18nAi.configure do |config|
+          config.ai_settings = {
+            provider: "anthropic",
+            model: "claude-3-haiku-20240307",
+            access_token: ENV.fetch("ANTHROPIC_ACCESS_TOKEN", "ABC123")
+          }
         end
       end
 
-      describe "#chat" do
-        let(:locale) { :fr }
-        let(:text) { "some text" }
-        let(:response) { { "content" => [{ "text" => "translated text" }] } }
+      let :es_yaml do
+        <<~YAML.chomp
+          es:
+            good_morning: "Buenos días"
+        YAML
+      end
 
-        before do
-          allow_any_instance_of(Anthropic::Client).to receive(:messages).and_return(response)
-        end
-
-        it "sends a message to the Anthropic client" do
-          expect_any_instance_of(Anthropic::Client).to receive(:messages).with(
-            parameters: {
-              model: config[:model],
-              messages: [
-                { role: "user", content: client.send(:chat_prompt, locale, text) }
-              ]
-            }
-          )
-          client.chat(locale, text)
-        end
-
-        it "returns the parsed response" do
-          expect(client.chat(locale, text)).to eq("translated text")
-        end
-
-        context "when an error occurs" do
-          before do
-            allow_any_instance_of(Anthropic::Client).to receive(:messages).and_raise(StandardError.new("test error"))
+      describe "#translate_content" do
+        it "returns the translated content" do
+          VCR.use_cassette("anthropic_success") do
+            content = file_fixture("en.yml").read
+            client = I18nAi::Clients::AnthropicClient.new
+            expect(client.translate_content(:es, content)).to eq(es_yaml)
           end
-
-          it "handles the error" do
-            expect(client).to receive(:handle_error).with(an_instance_of(StandardError))
-            client.chat(locale, text)
-          end
-        end
-      end
-
-      describe "#parse_response" do
-        let(:response) { { "content" => [{ "text" => "translated text" }] } }
-
-        it "parses the response correctly" do
-          expect(client.send(:parse_response, response)).to eq("translated text")
-        end
-
-        context "when the response is invalid" do
-          let(:response) { nil }
-
-          it "handles the error" do
-            expect(client).to receive(:handle_error).with(an_instance_of(NoMethodError))
-            client.send(:parse_response, response)
-          end
-        end
-      end
-
-      describe "#handle_error" do
-        let(:error) { NoMethodError.new("test error") }
-
-        it "prints the error message" do
-          expect { client.send(:handle_error, error) }.to output("Error: test error\n").to_stdout
         end
       end
     end

--- a/spec/clients/anthropic_client_spec.rb
+++ b/spec/clients/anthropic_client_spec.rb
@@ -31,7 +31,7 @@ module I18nAi
             parameters: {
               model: config[:model],
               messages: [
-                { role: "user", content: client.send(:content, locale, text) }
+                { role: "user", content: client.send(:chat_prompt, locale, text) }
               ]
             }
           )

--- a/spec/clients/anthropic_client_spec.rb
+++ b/spec/clients/anthropic_client_spec.rb
@@ -1,33 +1,29 @@
 # frozen_string_literal: true
 
-module I18nAi
-  module Clients
-    RSpec.describe AnthropicClient do
-      before do
-        I18nAi.configure do |config|
-          config.ai_settings = {
-            provider: "anthropic",
-            model: "claude-3-haiku-20240307",
-            access_token: ENV.fetch("ANTHROPIC_ACCESS_TOKEN", "ABC123")
-          }
-        end
-      end
+RSpec.describe I18nAi::Clients::AnthropicClient do
+  before do
+    I18nAi.configure do |config|
+      config.ai_settings = {
+        provider: "anthropic",
+        model: "claude-3-haiku-20240307",
+        access_token: ENV.fetch("ANTHROPIC_ACCESS_TOKEN", "ABC123")
+      }
+    end
+  end
 
-      let :es_yaml do
-        <<~YAML.chomp
-          es:
-            good_morning: "Buenos días"
-        YAML
-      end
+  let :es_yaml do
+    <<~YAML.chomp
+      es:
+        good_morning: "Buenos días"
+    YAML
+  end
 
-      describe "#translate_content" do
-        it "returns the translated content" do
-          VCR.use_cassette("anthropic_success") do
-            content = file_fixture("en.yml").read
-            client = I18nAi::Clients::AnthropicClient.new
-            expect(client.translate_content(:es, content)).to eq(es_yaml)
-          end
-        end
+  describe "#translate_content" do
+    it "returns the translated content" do
+      VCR.use_cassette("anthropic_success") do
+        content = file_fixture("en.yml").read
+        client = I18nAi::Clients::AnthropicClient.new
+        expect(client.translate_content(:es, content)).to eq(es_yaml)
       end
     end
   end

--- a/spec/clients/base_client_spec.rb
+++ b/spec/clients/base_client_spec.rb
@@ -1,20 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe I18nAi::Clients::BaseClient do
-  describe "#content" do
-    it "generates the correct content string" do
-      base_client = I18nAi::Clients::BaseClient.new
-      locale = :es
-      text = "some text"
-      expected_content = "Translate the following YAML content to ES and make sure to retain the keys in english except the first key which is the 2 letter language code:\n\nsome text"
-      expect(base_client.content(locale, text)).to eq(expected_content)
-    end
-  end
-
-  describe "#parse_response" do
+  describe "#translate_content" do
     it "raises NotImplementedError" do
       base_client = I18nAi::Clients::BaseClient.new
-      expect { base_client.parse_response("some response") }.to raise_error(NotImplementedError)
+      locale = :es
+      locale_file = file_fixture("en.yml")
+      content = locale_file.read
+      expect {
+        base_client.translate_content(locale, content)
+      }.to raise_error(NotImplementedError)
     end
   end
 end

--- a/spec/clients/open_ai_client_spec.rb
+++ b/spec/clients/open_ai_client_spec.rb
@@ -30,7 +30,7 @@ module I18nAi
           expect_any_instance_of(OpenAI::Client).to receive(:chat).with(
             parameters: {
               model: config[:model],
-              messages: [{ role: "user", content: client.send(:content, locale, text) }],
+              messages: [{ role: "user", content: client.send(:chat_prompt, locale, text) }],
               max_tokens: 5000
             }
           )

--- a/spec/clients/open_ai_client_spec.rb
+++ b/spec/clients/open_ai_client_spec.rb
@@ -1,81 +1,29 @@
 # frozen_string_literal: true
 
-module I18nAi
-  module Clients
-    RSpec.describe OpenAiClient do
-      let(:config) { { access_token: "test_token", model: "test_model" } }
-      let(:client) { described_class.new }
+RSpec.describe I18nAi::Clients::OpenAiClient do
+  before do
+    I18nAi.configure do |config|
+      config.ai_settings = {
+        provider: "openai",
+        model: "gpt-4o-mini",
+        access_token: ENV.fetch("OPENAI_ACCESS_TOKEN", "ABC123")
+      }
+    end
+  end
 
-      before do
-        allow(I18nAi).to receive_message_chain(:configuration, :ai_settings).and_return(config)
-      end
+  let :es_yaml do
+    <<~YAML.chomp
+      es:
+        good_morning: "Buenos Días"
+    YAML
+  end
 
-      describe "#initialize" do
-        it "initializes the OpenAI client with the correct access token" do
-          expect(OpenAI::Client).to receive(:new).with(access_token: config[:access_token], log_errors: true)
-          client
-        end
-      end
-
-      describe "#chat" do
-        let(:locale) { :fr }
-        let(:text) { "some text" }
-        let(:response) { { "choices" => [{ "message" => { "content" => "translated text" } }] } }
-
-        before do
-          allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(response)
-        end
-
-        it "sends a message to the OpenAI client" do
-          expect_any_instance_of(OpenAI::Client).to receive(:chat).with(
-            parameters: {
-              model: config[:model],
-              messages: [{ role: "user", content: client.send(:chat_prompt, locale, text) }],
-              max_tokens: 5000
-            }
-          )
-          client.chat(locale, text)
-        end
-
-        it "returns the parsed response" do
-          expect(client.chat(locale, text)).to eq("translated text")
-        end
-
-        context "when an error occurs" do
-          before do
-            allow_any_instance_of(OpenAI::Client).to receive(:chat).and_raise(StandardError.new("test error"))
-          end
-
-          it "handles the error" do
-            expect(client).to receive(:handle_error).with(an_instance_of(StandardError))
-            client.chat(locale, text)
-          end
-        end
-      end
-
-      describe "#parse_response" do
-        let(:response) { { "choices" => [{ "message" => { "content" => "translated text" } }] } }
-
-        it "parses the response correctly" do
-          expect(client.send(:parse_response, response)).to eq("translated text")
-        end
-
-        context "when the response is invalid" do
-          let(:response) { nil }
-
-          it "handles NoMethodError" do
-            expect(client).to receive(:handle_error).with(an_instance_of(NoMethodError))
-            client.send(:parse_response, response)
-          end
-        end
-      end
-
-      describe "#handle_error" do
-        let(:error) { StandardError.new("test error") }
-
-        it "prints the error message" do
-          expect { client.send(:handle_error, error) }.to output("Error: test error\n").to_stdout
-        end
+  describe "#translate_content" do
+    it "returns the translated content" do
+      VCR.use_cassette("openai_success") do
+        content = file_fixture("en.yml").read
+        client = I18nAi::Clients::OpenAiClient.new
+        expect(client.translate_content(:es, content)).to eq(es_yaml)
       end
     end
   end

--- a/spec/fixtures/files/en.yml
+++ b/spec/fixtures/files/en.yml
@@ -1,0 +1,2 @@
+en:
+  good_morning: "Good Morning"

--- a/spec/fixtures/vcr_cassettes/anthropic_success.yml
+++ b/spec/fixtures/vcr_cassettes/anthropic_success.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"model":"claude-3-haiku-20240307","messages":[{"role":"user","content":"Translate
+        the following YAML content to the language of the country using the ISO 639
+        language code\nof es. Make sure to retain the keys in english except the first
+        key which is the 2 letter language code:\n\n\"\"\"\"\nen:\n  good_morning:
+        \"Good Morning\"\"\n\"\"\"\"\n\nReturn only YAML content without explanation.\n\nExample:\n\n  {{two_letter_locale_abbrev}}:\n    key_1:
+        \"value1\"\n"}],"max_tokens":1024}'
+    headers:
+      X-Api-Key:
+      - "<ACCESS_TOKEN>"
+      Anthropic-Version:
+      - '2023-06-01'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Aug 2024 09:28:06 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Requests-Limit:
+      - '4000'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '3999'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2024-08-07T09:28:56Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '400000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '400000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2024-08-07T09:28:06Z'
+      Request-Id:
+      - req_01A2fHPyZ71TVEkx4ghs1czA
+      X-Cloud-Trace-Context:
+      - 985e69e43641fe0ed83fc4aad0ac017f
+      Via:
+      - 1.1 google
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8af63c0ad997e540-MNL
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJpZCI6Im1zZ18wMUh3M3VkeVdjUDFnVlBKUmN6MzNWdEsiLCJ0eXBlIjoibWVzc2FnZSIsInJvbGUiOiJhc3Npc3RhbnQiLCJtb2RlbCI6ImNsYXVkZS0zLWhhaWt1LTIwMjQwMzA3IiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiZXM6XG4gIGdvb2RfbW9ybmluZzogXCJCdWVub3MgZMOtYXNcIiJ9XSwic3RvcF9yZWFzb24iOiJlbmRfdHVybiIsInN0b3Bfc2VxdWVuY2UiOm51bGwsInVzYWdlIjp7ImlucHV0X3Rva2VucyI6MTA2LCJvdXRwdXRfdG9rZW5zIjoxNn19
+  recorded_at: Wed, 07 Aug 2024 09:28:06 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/anthropic_success.yml
+++ b/spec/fixtures/vcr_cassettes/anthropic_success.yml
@@ -9,8 +9,8 @@ http_interactions:
         the following YAML content to the language of the country using the ISO 639
         language code\nof es. Make sure to retain the keys in english except the first
         key which is the 2 letter language code:\n\n\"\"\"\"\nen:\n  good_morning:
-        \"Good Morning\"\"\n\"\"\"\"\n\nReturn only YAML content without explanation.\n\nExample:\n\n  {{two_letter_locale_abbrev}}:\n    key_1:
-        \"value1\"\n"}],"max_tokens":1024}'
+        \"Good Morning\"\"\n\"\"\"\"\n\nReturn only the YAML content without explanation.\n\nExample
+        Return YAML:\n\n\"\"\"\n{{ISO_639 language code}}:\n  key_1: \"value1\"\n\"\"\"\n"}],"max_tokens":4096}'
     headers:
       X-Api-Key:
       - "<ACCESS_TOKEN>"
@@ -30,7 +30,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Aug 2024 09:28:06 GMT
+      - Wed, 07 Aug 2024 10:20:15 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -42,17 +42,17 @@ http_interactions:
       Anthropic-Ratelimit-Requests-Remaining:
       - '3999'
       Anthropic-Ratelimit-Requests-Reset:
-      - '2024-08-07T09:28:56Z'
+      - '2024-08-07T10:20:56Z'
       Anthropic-Ratelimit-Tokens-Limit:
       - '400000'
       Anthropic-Ratelimit-Tokens-Remaining:
       - '400000'
       Anthropic-Ratelimit-Tokens-Reset:
-      - '2024-08-07T09:28:06Z'
+      - '2024-08-07T10:20:15Z'
       Request-Id:
-      - req_01A2fHPyZ71TVEkx4ghs1czA
+      - req_01T8uPPQEP28FkgqjyYviNoU
       X-Cloud-Trace-Context:
-      - 985e69e43641fe0ed83fc4aad0ac017f
+      - 4dacf66e23b5aba200d051e4b3e976c7
       Via:
       - 1.1 google
       Cf-Cache-Status:
@@ -60,10 +60,10 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 8af63c0ad997e540-MNL
+      - 8af68870cbb6e540-MNL
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        eyJpZCI6Im1zZ18wMUh3M3VkeVdjUDFnVlBKUmN6MzNWdEsiLCJ0eXBlIjoibWVzc2FnZSIsInJvbGUiOiJhc3Npc3RhbnQiLCJtb2RlbCI6ImNsYXVkZS0zLWhhaWt1LTIwMjQwMzA3IiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiZXM6XG4gIGdvb2RfbW9ybmluZzogXCJCdWVub3MgZMOtYXNcIiJ9XSwic3RvcF9yZWFzb24iOiJlbmRfdHVybiIsInN0b3Bfc2VxdWVuY2UiOm51bGwsInVzYWdlIjp7ImlucHV0X3Rva2VucyI6MTA2LCJvdXRwdXRfdG9rZW5zIjoxNn19
-  recorded_at: Wed, 07 Aug 2024 09:28:06 GMT
+      encoding: UTF-8
+      string: '{"id":"msg_01UfBgSiBN1cxEkN9NiSVw6C","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[{"type":"text","text":"es:\n  good_morning:
+        \"Buenos días\""}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":111,"output_tokens":15}}'
+  recorded_at: Wed, 07 Aug 2024 10:20:15 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/openai_success.yml
+++ b/spec/fixtures/vcr_cassettes/openai_success.yml
@@ -9,8 +9,8 @@ http_interactions:
         the following YAML content to the language of the country using the ISO 639
         language code\nof es. Make sure to retain the keys in english except the first
         key which is the 2 letter language code:\n\n\"\"\"\"\nen:\n  good_morning:
-        \"Good Morning\"\"\n\"\"\"\"\n\nReturn only the YAML content without explanation.\n\nExample:\n\n  {{two_letter_locale_abbrev}}:\n    key_1:
-        \"value1\"\n"}],"max_tokens":5000}'
+        \"Good Morning\"\"\n\"\"\"\"\n\nReturn only the YAML content without explanation.\n\nExample
+        Return YAML:\n\n\"\"\"\n{{ISO_639 language code}}:\n  key_1: \"value1\"\n\"\"\"\n"}],"max_tokens":5000}'
     headers:
       Content-Type:
       - application/json
@@ -28,7 +28,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Aug 2024 09:49:54 GMT
+      - Wed, 07 Aug 2024 10:20:17 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,7 +38,7 @@ http_interactions:
       Openai-Organization:
       - narra-labs
       Openai-Processing-Ms:
-      - '627'
+      - '1326'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
@@ -50,32 +50,55 @@ http_interactions:
       X-Ratelimit-Remaining-Requests:
       - '9999'
       X-Ratelimit-Remaining-Tokens:
-      - '194907'
+      - '194903'
       X-Ratelimit-Reset-Requests:
       - 8.64s
       X-Ratelimit-Reset-Tokens:
-      - 1.527s
+      - 1.528s
       X-Request-Id:
-      - req_547f1d3d64233228f8053e143e836249
+      - req_60b52a993f7077f2ea0d922deb3abebd
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=k_rcQHMug7DvFNt60liMCIeFyDqYCLT_3CjN_KTYI_A-1723024194-1.0.1.1-BaYtkSQrbDN8hLTzEijiz8.66oDKvyz9D.XUO9QjEwt9hgAHT.07SGvAzavfNF.rm47l6mpGAY6OWzM.McJujw;
-        path=/; expires=Wed, 07-Aug-24 10:19:54 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=27FTbZ_qhSLnp1zr.pm3prlBwbYtBZ1d1KsCf7Dj_bo-1723026017-1.0.1.1-ZAvJy34jqXVmkQ.SfesUHByg0z3TIW4dghv8na_0opjXCj5yrmPP7TbZVw4caFATdLPCAAT5WyXiqdwd9CzZcw;
+        path=/; expires=Wed, 07-Aug-24 10:50:17 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=uy5zewtAHpd.oVusgUhX2GVLyS2_8vzqn3ytXPqZ3l0-1723024194545-0.0.1.1-604800000;
+      - _cfuvid=4p58RyEmclVcRDxDTADsmYHU4L0wpZ77putvrBKtdFI-1723026017438-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       X-Content-Type-Options:
       - nosniff
       Server:
       - cloudflare
       Cf-Ray:
-      - 8af65bf9abc285bb-HKG
+      - 8af68875be0585ce-HKG
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        ewogICJpZCI6ICJjaGF0Y21wbC05dFhhazhxdVhJYlE5N0ZFTWNsMTNiU015Vlg5YyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTcyMzAyNDE5NCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiYGBgeWFtbFxuZXM6XG4gIGdvb2RfbW9ybmluZzogXCJCdWVub3MgRMOtYXNcIlxuYGBgIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwKICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogOTQsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiAxNiwKICAgICJ0b3RhbF90b2tlbnMiOiAxMTAKICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfNDgxOTZiYzY3YSIKfQo=
-  recorded_at: Wed, 07 Aug 2024 09:49:54 GMT
+      encoding: UTF-8
+      string: |
+        {
+          "id": "chatcmpl-9tY48QF4YliQG3W0U93gDtImBK5eu",
+          "object": "chat.completion",
+          "created": 1723026016,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "```yaml\nes:\n  good_morning: \"Buenos Días\"\n```",
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 97,
+            "completion_tokens": 16,
+            "total_tokens": 113
+          },
+          "system_fingerprint": "fp_48196bc67a"
+        }
+  recorded_at: Wed, 07 Aug 2024 10:20:17 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/openai_success.yml
+++ b/spec/fixtures/vcr_cassettes/openai_success.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Translate
+        the following YAML content to the language of the country using the ISO 639
+        language code\nof es. Make sure to retain the keys in english except the first
+        key which is the 2 letter language code:\n\n\"\"\"\"\nen:\n  good_morning:
+        \"Good Morning\"\"\n\"\"\"\"\n\nReturn only the YAML content without explanation.\n\nExample:\n\n  {{two_letter_locale_abbrev}}:\n    key_1:
+        \"value1\"\n"}],"max_tokens":5000}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Aug 2024 09:49:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Organization:
+      - narra-labs
+      Openai-Processing-Ms:
+      - '627'
+      Openai-Version:
+      - '2020-10-01'
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '200000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '194907'
+      X-Ratelimit-Reset-Requests:
+      - 8.64s
+      X-Ratelimit-Reset-Tokens:
+      - 1.527s
+      X-Request-Id:
+      - req_547f1d3d64233228f8053e143e836249
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=k_rcQHMug7DvFNt60liMCIeFyDqYCLT_3CjN_KTYI_A-1723024194-1.0.1.1-BaYtkSQrbDN8hLTzEijiz8.66oDKvyz9D.XUO9QjEwt9hgAHT.07SGvAzavfNF.rm47l6mpGAY6OWzM.McJujw;
+        path=/; expires=Wed, 07-Aug-24 10:19:54 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=uy5zewtAHpd.oVusgUhX2GVLyS2_8vzqn3ytXPqZ3l0-1723024194545-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8af65bf9abc285bb-HKG
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC05dFhhazhxdVhJYlE5N0ZFTWNsMTNiU015Vlg5YyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTcyMzAyNDE5NCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiYGBgeWFtbFxuZXM6XG4gIGdvb2RfbW9ybmluZzogXCJCdWVub3MgRMOtYXNcIlxuYGBgIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwKICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogOTQsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiAxNiwKICAgICJ0b3RhbF90b2tlbnMiOiAxMTAKICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfNDgxOTZiYzY3YSIKfQo=
+  recorded_at: Wed, 07 Aug 2024 09:49:54 GMT
+recorded_with: VCR 6.2.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,10 @@ VCR.configure do |config|
   config.filter_sensitive_data("<ACCESS_TOKEN>") do
     I18nAi.configuration.ai_settings[:access_token]
   end
+  config.before_record do |interaction|
+    interaction.response.body.force_encoding("UTF-8")
+  end
+  config.default_cassette_options = { decode_compressed_response: true }
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
   config.hook_into :webmock
   config.filter_sensitive_data("<ACCESS_TOKEN>") do
-    puts "==> FILTER SENSITIVE DATA access_token"
     I18nAi.configuration.ai_settings[:access_token]
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,17 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.add_setting :file_fixture_path, default: "spec/fixtures/files"
+
+  config.include Module.new {
+    def file_fixture(file_name)
+      path = RSpec.configuration.file_fixture_path
+      file_path = File.join(path, file_name)
+      raise ArgumentError, "the directory '#{path}' does not contain a file named '#{file_name}'" unless File.exist?(file_path)
+      File.new(file_path)
+    end
+  }
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
This modifies the `I18nAi::Clients::BaseClient` class interface so we can easily extract data. The content extraction used to be extracted under the i18n railtie class so this moves the behavior to the client.

This also adds the simple API of just calling `translate_content(locale, content)` to the instance of the client as the only public method.

The interface for adding another base class is now easier, simply add `chat` and `extract_translated_content` methods, for example:

```ruby
class MyNewAiService < I18nAi::Clients::BaseClient
  def translate_content(locale, content)
    # implementation in base client but it's basically:
    chat_content = chat(locale, content)
    extract_translated_content(chat_content)
  end

  private

  def chat(locale, text)
    # ... make request to service
    # return some string value
  end

  def extract_translated_content(return_value_from_chat_method)
    # return string here
  end 
end

# Usage
yaml_content =<<~YAML.chomp
  en:
    good_morning: "Good Morning"
YAML

my_ai_service = MyNewAiService.new
my_ai_service.translate_content(:es, yaml_content)
=> """
es:
  good_morning: "Buenos Dias"
"""
```